### PR TITLE
Add Self-host private pub packages - minibar.dev - Pascal Welsch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you were a speaker at FlutterCon, please submit a PR and add your talk and sl
 | | | Thursday | 11:10 AM | | 
 | | | Thursday | 11:10 AM | | 
 | Building your very own devtools extension | [Enzo Conty](https://x.com/enzoconty)| Thursday | 12:05 PM | [slides](https://docs.google.com/presentation/d/e/2PACX-1vSPZgpFjAGwnaRXvtAITEqsLsjpJdCe6LfSmLr6vUiTkr3lje7k9zHSabedtZ293GzhItCQZqPSZzy9/pub?start=false&loop=false&delayms=3000) | 
-| | | Thursday | 12:05 PM | | 
+| Self-host private pub packages - minibar.dev | [Pascal Welsch](https://x.com/passsy) | Thursday | 12:05 PM | [slides](https://docs.google.com/presentation/d/1xkCcJaEEECe_2MknAGSsMm1FLGlsga1ggXk4SGp7WAY/edit?usp=sharing) | 
 | | | Thursday | 12:05 PM | | 
 | | | Thursday | 12:05 PM | | 
 | | | Thursday | 1:25 PM  | |


### PR DESCRIPTION

Description
>Self-hosting Dart and Flutter packages isn't easy but required when sharing packages in an enterprise environment. Today, getting your own pub server running is either pricey or maintenance-intensive. Without being cautious, your solution might miss critical access policies.
>
>As a Flutter agency, we encountered significant difficulties sharing our design system across multiple projects and clients. >We needed a robust solution that could meet our needs, yet be affordable.
>
>This talk compares existing solutions as well as our journey of hosting our own pub repository in an agency setup, even allowing us to use our own domain at almost zero cost.
>
> This talk is not sponsored by any provider, neither promotes our own solution unless it is completely open source as part of the FlutterCommunity.